### PR TITLE
Added wpml-config.xml field to make the custom fields translatable

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,6 @@
+<wpml-config>
+	<custom-fields>
+        <custom-field action="translate">custom_price_string</custom-field>
+        <custom-field action="translate">custom_from_string</custom-field>
+    </custom-fields>	
+</wpml-config>


### PR DESCRIPTION
### Description
By default, WPML ignores our custom fields on their translation GUI and customers need to change the translation settings of the plugin (WPML>Settings>Custom Fields Translation) to make them translatable. 

### Fix
WPML allows developers to specify the translation options of the plugin content (custom fields, taxonomies, post types, etc) using a file named wpml-config.xml. I've added it to the plugin root folder to make the `custom_price_string` and `custom_from_string` fields translatable by default with WPML.

### Ticket
https://secure.helpscout.net/conversation/781747664/27846/

### Issue
Fixes #4 